### PR TITLE
Add alternative covariance options 

### DIFF
--- a/R/check_blocks.r
+++ b/R/check_blocks.r
@@ -53,7 +53,7 @@ check_blocks <- function(blocks, init = FALSE, n = 2,
                               return(x)
                               }
                             )
-            message("Missing rownames are automatically labeled.")
+            if (!quiet) {message("Missing rownames are automatically labeled.")}
         }
         else
             stop_rgcca("Blocks should have rownames.")
@@ -84,7 +84,7 @@ check_blocks <- function(blocks, init = FALSE, n = 2,
     
     if (any(sapply(blocks, function(x) is.null(colnames(x)))))
     {
-      message("Missing colnames are automatically labeled.")
+      if (!quiet) {message("Missing colnames are automatically labeled.")}
       blocks1 = lapply(seq_along(blocks),
                        function(x){
                          if(is.null(colnames(blocks[[x]]))){

--- a/R/cov2.R
+++ b/R/cov2.R
@@ -14,6 +14,7 @@
 
 cov2 = function (x, y = NULL, bias = TRUE, alternateCov = NULL)
 {
+  n = NROW(x)
   options = c("mcd", "cellwise", "mve")
 
   stopifnot(alternateCov %in% options)

--- a/R/cov2.R
+++ b/R/cov2.R
@@ -12,9 +12,48 @@
 # @title Variance and Covariance (Matrices)
 # @importFrom stats cov
 
-cov2 = function (x, y = NULL, bias = TRUE)
+cov2 = function (x, y = NULL, bias = TRUE, alternateCov = NULL)
 {
-  n = NROW(x)
+  options = c("mcd", "cellwise", "mve")
+
+  stopifnot(alternateCov %in% options)
+
+  # Annoying workaround because R sucks at handling NULL
+  if (sum(alternateCov == "cellwise") > 0) {
+    locScale.x <- cellWise::estLocScale(x)
+    # the wrapped data is stored in $Xw. covariances get computed on this.
+    Xw.x <- cellWise::wrap(x, locScale.x$loc, locScale.x$scale)$Xw    
+    if (is.null(y)) {
+      Xw.x.cov <- cov(Xw.x)
+      return(ifelse(bias, Xw.x.cov, (n-1)/n * Xw.x.cov))
+    } else {
+      locScale.y <- cellWise::estLocScale(y)
+      Xw.y <- cellWise::wrap(y, locScale.y$loc, locScale.y$scale)$Xw
+      Xw.xy.cov <- cov(Xw.x, Xw.y)
+      return(ifelse(bias, Xw.xy.cov, (n-1)/n * Xw.xy.cov))
+    }
+  }
+
+  if (sum(alternateCov == "mcd") > 0) {    
+    if (is.null(y)) {
+      cov <- robustbase::covMcd(x)$cov  
+    } else {
+      cov <- robustbase::covMcd(cbind(x,y))$cov  
+    }
+    return(ifelse(bias, cov, (n-1)/n * cov))
+  }
+
+  if (sum(alternateCov == "mve") > 0) {
+    if (is.null(y)) {
+      cov <- rrcov::CovMve(x)$cov
+    } else {
+      cov <- rrcov::CovMve(cbind(x,y))$cov
+    }
+    # browser()
+    return(ifelse(bias, cov, (n-1)/n * cov))
+  }
+
+  # Original
 
   if (is.null(y)) {
     x = as.matrix(x)
@@ -34,5 +73,6 @@ cov2 = function (x, y = NULL, bias = TRUE)
       C = stats::cov(x, y, use = "pairwise.complete.obs")
     }
   }
-return(C)
+  # browser()
+  return(C)
 }

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -191,8 +191,8 @@ rgcca <- function(blocks, method = "rgcca",
                   sparsity = rep(1, length(blocks)),
                   init = "svd", bias = TRUE, tol = 1e-08,
                   response = NULL, superblock = FALSE,
-                  NA_method = "nipals", verbose = FALSE, quiet = TRUE){
-
+                  NA_method = "nipals", verbose = FALSE, 
+                  quiet = TRUE, alternateCov=NULL) {
     if(is(blocks, "permutation")) {
         message("All the parameters were imported from the fitted rgcca_permutation object.")
         scale_block = blocks$call$scale_block
@@ -354,6 +354,9 @@ rgcca <- function(blocks, method = "rgcca",
     if (warn_on && !quiet)
         message("Analysis in progress ...")
 
+    # gcca function comes from above
+    # if method is in "sgcca", "spca", "spls", use sgcca
+    # else, use rgccad
     func <- quote(
         gcca(
             blocks = opt$blocks,
@@ -365,7 +368,8 @@ rgcca <- function(blocks, method = "rgcca",
             bias = bias,
             tol = tol,
             quiet = quiet,
-            na.rm = na.rm
+            na.rm = na.rm,
+            alternateCov = alternateCov
         )
     )
 

--- a/R/rgccad.R
+++ b/R/rgccad.R
@@ -176,7 +176,7 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
                   tau = rep(1, length(blocks)),
                   ncomp = rep(1, length(blocks)), scheme = "centroid",
                   init = "svd", bias = TRUE, tol = 1e-08, verbose = TRUE,
-                  na.rm = TRUE, quiet = FALSE)
+                  na.rm = TRUE, quiet = FALSE, alternateCov = NULL)
 {
 
   if (mode(scheme) != "function") {
@@ -225,11 +225,13 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
   if (is.vector(tau))
     rgcca.result <- rgccak(blocks, connection, tau = tau, scheme = scheme,
                            init = init, bias = bias, tol = tol,
-                           verbose = verbose, na.rm = na.rm)
+                           verbose = verbose, na.rm = na.rm, 
+                           alternateCov = alternateCov)
   else
     rgcca.result <- rgccak(blocks, connection, tau = tau[1, ], scheme = scheme,
                            init = init, bias = bias, tol = tol,
-                           verbose = verbose, na.rm = na.rm)
+                           verbose = verbose, na.rm = na.rm, 
+                           alternateCov = alternateCov)
   computed_tau[1, ] = rgcca.result$tau
 
   for (b in 1:J) Y[[b]][, 1] <- rgcca.result$Y[, b, drop = FALSE]
@@ -253,11 +255,13 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
       if (is.vector(tau))
         rgcca.result <- rgccak(R, connection, tau = tau, scheme = scheme,
                                init = init, bias = bias, tol = tol,
-                               verbose = verbose, na.rm = na.rm)
+                               verbose = verbose, na.rm = na.rm,
+                               alternateCov = alternateCov)
       else
         rgcca.result <- rgccak(R, connection, tau = tau[n, ], scheme = scheme,
                                init = init, bias = bias, tol = tol,
-                               verbose = verbose, na.rm = na.rm)
+                               verbose = verbose, na.rm = na.rm,
+                               alternateCov = alternateCov)
       computed_tau[n, ] = rgcca.result$tau
 
       AVE_inner[n] <- rgcca.result$AVE_inner
@@ -277,9 +281,10 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
     colnames(Y[[b]]) = paste0("comp", 1:max(ncomp))
   }
 
+  # browser()
   for (j in 1:J) AVE_X[[j]] = apply(
     cor(blocks[[j]], Y[[j]], use = "pairwise.complete.obs")^2, 2, mean)
-
+  # browser()
   outer = matrix(unlist(AVE_X), nrow = max(ncomp))
 
   for (j in 1:max(ncomp))

--- a/R/sgcca.R
+++ b/R/sgcca.R
@@ -137,7 +137,8 @@ sgcca <- function(blocks, connection = 1 - diag(length(blocks)),
                   sparsity = rep(1, length(blocks)),
                   ncomp = rep(1, length(blocks)), scheme = "centroid",
                   init = "svd", bias = TRUE, tol = .Machine$double.eps,
-                  verbose = FALSE,   quiet = FALSE, na.rm = TRUE){
+                  verbose = FALSE,   quiet = FALSE, na.rm = TRUE,
+                  alternateCov = NULL){
 
   # ndefl number of deflation per block
   ndefl <- ncomp - 1
@@ -173,12 +174,12 @@ sgcca <- function(blocks, connection = 1 - diag(length(blocks)),
     sgcca.result <- sgccak(blocks, connection, sparsity = sparsity,
                            scheme = scheme, init = init, bias = bias,
                            tol = tol, verbose = verbose, quiet = quiet,
-                           na.rm = na.rm)
+                           na.rm = na.rm, alternateCov = alternateCov)
   } else {
     sgcca.result <- sgccak(blocks, connection, sparsity = sparsity[1, ],
                            scheme = scheme, init = init, bias = bias,
                            tol = tol, verbose = verbose, quiet = quiet,
-                           na.rm = na.rm)
+                           na.rm = na.rm, alternateCov = alternateCov)
   }
 
   for (b in 1:J) Y[[b]][, 1] <- sgcca.result$Y[, b, drop = FALSE]
@@ -208,12 +209,12 @@ sgcca <- function(blocks, connection = 1 - diag(length(blocks)),
         sgcca.result <- sgccak(R, connection, sparsity = sparsity,
                                scheme = scheme, init = init, bias = bias,
                                tol = tol, verbose = verbose, quiet = quiet,
-                               na.rm = na.rm)
+                               na.rm = na.rm, alternateCov = alternateCov)
       } else {
         sgcca.result <- sgccak(R, connection, sparsity = sparsity[n, ],
                                scheme = scheme, init = init, bias = bias,
                                tol = tol, verbose = verbose, quiet = quiet,
-                               na.rm = na.rm)
+                               na.rm = na.rm, alternateCov = alternateCov)
       }
 
       AVE_inner[n] <- sgcca.result$AVE_inner

--- a/R/sgccak.R
+++ b/R/sgccak.R
@@ -22,7 +22,7 @@
 sgccak <-  function(A, C, sparsity = rep(1, length(A)), scheme = "centroid",
                     tol = .Machine$double.eps,
                     init = "svd", bias = TRUE, verbose = TRUE,
-                    quiet = FALSE, na.rm = TRUE){
+                    quiet = FALSE, na.rm = TRUE, alternateCov = NULL){
 
   J <- length(A)
   pjs = sapply(A, NCOL)
@@ -60,9 +60,9 @@ sgccak <-  function(A, C, sparsity = rep(1, length(A)), scheme = "centroid",
                                   horst = x,
                                   factorial = x**2,
                                   centroid = abs(x))
-          crit_old <- sum(C*g(cov2(Y, bias = bias)))
+          crit_old <- sum(C*g(cov2(Y, bias = bias, alternateCov = alternateCov)))
           },
-         crit_old <- sum(C*scheme(cov2(Y, bias = bias)))
+         crit_old <- sum(C*scheme(cov2(Y, bias = bias, alternateCov = alternateCov)))
   )
 
   if (mode(scheme) == "function")
@@ -73,7 +73,7 @@ sgccak <-  function(A, C, sparsity = rep(1, length(A)), scheme = "centroid",
       for (q in 1:J){
 
         if (mode(scheme) == "function") {
-          dgx = dg(cov2(Y[, q], Y, bias = bias))
+          dgx = dg(cov2(Y[, q], Y, bias = bias, alternateCov = alternateCov))
           CbyCovq = C[q, ]*dgx
         }
 
@@ -81,9 +81,9 @@ sgccak <-  function(A, C, sparsity = rep(1, length(A)), scheme = "centroid",
           if (scheme == "horst")
             CbyCovq <- C[q, ]
           if (scheme == "factorial")
-            CbyCovq <- C[q, ]*2*cov2(Y, Y[, q], bias = bias)
+            CbyCovq <- C[q, ]*2*cov2(Y, Y[, q], bias = bias, alternateCov = alternateCov)
           if (scheme == "centroid")
-            CbyCovq <- C[q, ]*sign(cov2(Y, Y[,q], bias = bias))
+            CbyCovq <- C[q, ]*sign(cov2(Y, Y[,q], bias = bias, alternateCov = alternateCov))
         }
 
         Z[, q] <- rowSums(mapply("*", CbyCovq,as.data.frame(Y)))
@@ -98,9 +98,9 @@ sgccak <-  function(A, C, sparsity = rep(1, length(A)), scheme = "centroid",
                                     horst = x,
                                     factorial = x**2,
                                     centroid = abs(x))
-            crit[iter] <- sum(C*g(cov2(Y, bias = bias)))
+            crit[iter] <- sum(C*g(cov2(Y, bias = bias, alternateCov = alternateCov)))
             },
-           crit[iter] <- sum(C*scheme(cov2(Y, bias = bias)))
+           crit[iter] <- sum(C*scheme(cov2(Y, bias = bias, alternateCov = alternateCov)))
     )
 
     # Print out intermediate fit


### PR DESCRIPTION
- Add additional argument `alternateCov` in the `cov2` function. It current supports MCD, MVE, and [cellWise](https://cran.r-project.org/web/packages/cellWise/index.html)
- All calls to `cov2` are changed to allow `alternateCov`, which is `NULL` by default
- This should not affect any existing functionality